### PR TITLE
Support ignorable flags on playlog.Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.0.0
+* playlog@3.1.0 に対応
+* AMFlow#getTickList() の引数を変更
+
 ## 2.0.0
 * playlog@3.0.0 に対応
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ AMFlow実装は、このメソッド呼び出し時、または呼び出し前�
 * authenticate
 * sendTick
 * sendEvent
-* getTicks
+* getTickList
 * putStartPoint
 * getStartPoint
 
@@ -95,7 +95,7 @@ AMFlow実装は、この `Permission` を元にその他のメソッドの動作
 sendTick(tick: playlog.Tick): void;
 ```
 
-`playlog.Tick` に含まれる `playlog.Event` の非永続化フラグが真の場合、そのイベントは `getTickList()` から除外されます。
+`playlog.Tick` に含まれる `playlog.Event` の非永続化フラグ (`playlog.EventFlags.Transient`) が真の場合、そのイベントは `getTickList()` から除外されます。
 
 ### onTick
 
@@ -146,10 +146,12 @@ offEvent(handler: (event: playlog.Event) => void): void;
 保存された `playlog.Tick` のリストを `playlog.TickList` の形式で取得します。このメソッドの呼び出しにはセッションの開始が必須です。
 
 ```
-getTickList(begin: number, end: number, callback: (error: Error, tickList: playlog.TickList) => void): void;
+getTickList(opts: GetTickListOptions, callback: (error: Error, tickList: playlog.TickList) => void): void;
 ```
 
-`begin` で指定されたフレーム番号を含むフレームから、`end` で指定されたフレーム番号を含まないフレームのリストとなります。
+`opts.begin` で指定されたフレーム番号を含むフレームから、`opts.end` で指定されたフレーム番号を含まないフレームのリストとなります。
+
+`opts.excludeEventFlags` で `playlog.TickList` に含まれる `playlog.Event` の除外条件を指定することができます。
 
 指定された範囲の `playlog.Tick` が一つも見つからない場合、`tickList` は `null` となります。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@akashic/amflow",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@akashic/playlog": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.0.0.tgz",
-      "integrity": "sha512-07hxbwac2t38FxuDYlA1Xtx2J7NDfP5i/efh3iOsP0IktzTH0MSVgDpPon6Na/BBCvfqJt5521PMKvoq8pEQOw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.1.0.tgz",
+      "integrity": "sha512-O0gByaFr8Cq7Xc9QVg2MamhxZIssfFXvGSEegyJhUz787xCQ4SK5R0fdN0cUMoPJJBay/6W17scG1G8ndxC24g=="
     },
     "@azu/format-text": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/amflow",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "The interface definition of AMFlow, a playlog communication interface",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -36,7 +36,7 @@
     "typescript": "~3.5.2"
   },
   "dependencies": {
-    "@akashic/playlog": "~3.0.0"
+    "@akashic/playlog": "~3.1.0"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"

--- a/src/AMFlow.ts
+++ b/src/AMFlow.ts
@@ -20,6 +20,24 @@ export interface GetStartPointOptions {
 	timestamp?: number;
 }
 
+export interface GetTickListOptions {
+	begin: number;
+	end: number;
+
+	/**
+	 * 除外する `playlog.Event` のフラグ。
+	 * この値が指定された場合、対象の `playlog.Event` を除外した `playlog.TickList` を返す。
+	 * 省略時は除外しない (すべての `playlog.Event` を `playlog.TickList` に含ませる)。
+	 */
+	excludeEventFlags?: {
+		/**
+		 * `playlog.EventFlags.Ignorable` フラグが有効の `playlog.Event` を除外するかどうか。真の場合は除外する。
+		 * 省略時は除外しない。
+		 */
+		ignorable?: boolean;
+	};
+}
+
 export interface AMFlow {
 	// 各メソッドの分類をカテゴリとして表す
 	// カテゴリ: セッション
@@ -73,8 +91,14 @@ export interface AMFlow {
 	// カテゴリ: キャッシュされたデータ
 	/**
 	 * 保存された `playlog.Tick` のリスト `[begin, end)` を `playlog.TickList` の形式で取得する。
+	 * @deprecated この引数は非推奨である。 `GetTickListOptions` を指定する方を利用すべきである。
 	 */
 	getTickList(begin: number, end: number, callback: (error: Error | null, tickList?: playlog.TickList) => void): void;
+
+	/**
+	 * 保存された `playlog.Tick` のリスト `[opts.begin, opts.end)` を `playlog.TickList` の形式で取得する。
+	 */
+	getTickList(opts: GetTickListOptions, callback: (error: Error | null, tickList?: playlog.TickList) => void): void;
 
 	/**
 	 * 開始地点情報を保存する。

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import * as Permission from "./Permission";
 import * as Error from "./Error";
 
 export import GetStartPointOptions = AMFlow.GetStartPointOptions;
+export import GetTickListOptions = AMFlow.GetTickListOptions;
 export import AMFlow = AMFlow.AMFlow;
 export import StartPoint = StartPoint.StartPoint;
 export import Permission = Permission.Permission;

--- a/test/amflow-mock-client.ts
+++ b/test/amflow-mock-client.ts
@@ -107,7 +107,11 @@ class MockClient implements AMFlow.AMFlow {
 		});
 		this.onEventHandlers = handlers;
 	}
-	getTickList(begin: number, end: number, callback: (error: Error | null, tickList?: playlog.TickList) => void): void {
+	getTickList(
+		optsOrBegin: number | AMFlow.GetTickListOptions,
+		endOrCallback: number | ((error: Error | null, tickList?: playlog.TickList) => void),
+		callback?: (error: Error | null, tickList?: playlog.TickList) => void
+	): void {
 		throw createAMFlowError("NotImplemented", "MockClient#getTickList is not implemented.");
 	}
 	putStartPoint(startPoint: AMFlow.StartPoint, callback: (error: Error | null) => void): void {


### PR DESCRIPTION
## このPullRequestが解決する内容
* https://github.com/akashic-games/playlog/pull/8 に対応します。
* `AMFlow#getTickList()` の引数を変更します
   * `playlog.EventFlag.Ignorable` に該当する `playlog.Event` を `AMFlow#getTickList()` の取得結果から除外できるように変更します
   * 旧 I/F は deprecated として存続します

## 破壊的変更
* **あり**

## TODO
- [x] https://github.com/akashic-games/playlog/pull/8 の publish