### PR TITLE
export GetTickListExcludeEventFlags interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.1.0
+* `GetTickListExcludeEventFlags` を export
+
 ## 3.0.0
 * playlog@3.1.0 に対応
 * AMFlow#getTickList() の引数を変更

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/amflow",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The interface definition of AMFlow, a playlog communication interface",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/AMFlow.ts
+++ b/src/AMFlow.ts
@@ -29,13 +29,15 @@ export interface GetTickListOptions {
 	 * この値が指定された場合、対象の `playlog.Event` を除外した `playlog.TickList` を返す。
 	 * 省略時は除外しない (すべての `playlog.Event` を `playlog.TickList` に含ませる)。
 	 */
-	excludeEventFlags?: {
-		/**
-		 * `playlog.EventFlags.Ignorable` フラグが有効の `playlog.Event` を除外するかどうか。真の場合は除外する。
-		 * 省略時は除外しない。
-		 */
-		ignorable?: boolean;
-	};
+	excludeEventFlags?: GetTickListExcludeEventFlags;
+}
+
+export interface GetTickListExcludeEventFlags {
+	/**
+	 * `playlog.EventFlags.Ignorable` フラグが有効の `playlog.Event` を除外するかどうか。真の場合は除外する。
+	 * 省略時は除外しない。
+	 */
+	ignorable?: boolean;
 }
 
 export interface AMFlow {


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

GetTickListOption.excludeEventFlags のフラグ指定箇所の型定義を export します。

## 破壊的な変更を含んでいるか?

- なし

