### PR TITLE
add persist credentials to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:


### PR DESCRIPTION
### やったこと
- release.yml からcheckoutオプションの`persist-credentials: false`を削除
  -  akashic-games/action-release が git push時にgithubユーザー情報を必要とするため